### PR TITLE
nautible/issues#2 - resolve merge miss.

### DIFF
--- a/azure/platform/outputs.tf
+++ b/azure/platform/outputs.tf
@@ -13,7 +13,3 @@ output "vnet_name" {
 output "subnet_ids" {
   value = module.vnet.subnet_ids
 }
-
-output "vnet_id" {
-  value = module.vnet.vnet_id
-}


### PR DESCRIPTION
マージをミスり、
output "vnet_id" {
  value = module.vnet.vnet_id
}
が二つ定義された状態になってしまったため、修正のPRになります。
実行し、エラーの解消、および現状態との差分無しを確認済。