### PR TITLE
SecretsManagerの操作権限追加

### DIFF
--- a/aws/app-ms/modules/common/main.tf
+++ b/aws/app-ms/modules/common/main.tf
@@ -41,6 +41,16 @@ resource "aws_iam_role_policy" "app_policy" {
       },
       {
           "Effect": "Allow",
+          "Action": [
+            "secretsmanager:GetResourcePolicy",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+            "secretsmanager:ListSecretVersionIds"            
+          ],
+          "Resource": "arn:aws:secretsmanager:*:${data.aws_caller_identity.self.account_id}:secret:nautible-*"
+      },
+      {
+          "Effect": "Allow",
           "Action": "ssm:GetParameter",
           "Resource": "arn:aws:ssm:*:${data.aws_caller_identity.self.account_id}:parameter/sample-*"
       },


### PR DESCRIPTION
SecretsManagerに機密情報を移動したためアクセス権を追加。
なお、ParameterStoreを利用するケース（機密でないパラメータ）のサンプルも今後作成するかもしれないので、いったんParameterStoreの権限はそのままにしています。