### PR TITLE
Feature/issue68

### DIFF
--- a/.github/workflows/terraform-aws-app.yml
+++ b/.github/workflows/terraform-aws-app.yml
@@ -49,6 +49,7 @@ on:
   pull_request:
     branches:
     - main
+    - feature/issue68
     paths:
     - "aws/terraform/nautible-aws-app/**"
     types:
@@ -56,6 +57,11 @@ on:
       - synchronize
       - reopened
       - closed
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   terraform:
     name: 'Terraform'
@@ -72,11 +78,10 @@ jobs:
       uses: actions/checkout@v2
 
     # configure AWS credentials
-    - name: configure AWS credentials
+    - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/nautible-dev-githubactions-infra-role
         aws-region: ap-northeast-1
       
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token

--- a/.github/workflows/terraform-aws-app.yml
+++ b/.github/workflows/terraform-aws-app.yml
@@ -49,7 +49,6 @@ on:
   pull_request:
     branches:
     - main
-    - feature/issue68
     paths:
     - "aws/terraform/nautible-aws-app/**"
     types:

--- a/.github/workflows/terraform-aws-platform.yml
+++ b/.github/workflows/terraform-aws-platform.yml
@@ -49,6 +49,7 @@ on:
   pull_request:
     branches:
     - main
+    - feature/issue68
     paths:
     - "aws/terraform/nautible-aws-platform/**"
     types:
@@ -56,6 +57,11 @@ on:
       - synchronize
       - reopened
       - closed
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   terraform:
     name: 'Terraform'
@@ -72,11 +78,10 @@ jobs:
       uses: actions/checkout@v2
 
     # configure AWS credentials
-    - name: configure AWS credentials
+    - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/nautible-dev-githubactions-infra-role
         aws-region: ap-northeast-1
       
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token

--- a/.github/workflows/terraform-aws-platform.yml
+++ b/.github/workflows/terraform-aws-platform.yml
@@ -49,7 +49,6 @@ on:
   pull_request:
     branches:
     - main
-    - feature/issue68
     paths:
     - "aws/terraform/nautible-aws-platform/**"
     types:

--- a/aws/platform/modules/eks/main.tf
+++ b/aws/platform/modules/eks/main.tf
@@ -98,7 +98,7 @@ module "eks" {
 
   }
   tags = {
-    Name = "kubernatis.io/cluster/${var.pjname}-eks-cluster"
+    Name = "kubernetes.io/cluster/${var.pjname}-eks-cluster"
   }
 
 }

--- a/aws/platform/modules/oidc/main.tf
+++ b/aws/platform/modules/oidc/main.tf
@@ -70,3 +70,88 @@ resource "aws_iam_role_policy" "githubactions_ecr_access_role_policy" {
 }
 POLICY
 }
+
+resource "aws_iam_role" "githubactions_infra_role" {
+  name = "${var.pjname}-githubactions-infra-role"
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  ]
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Principal": {
+        "Federated": "${aws_iam_openid_connect_provider.oidc_provider.id}"
+      },
+      "Condition": {
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:${var.oidc.github_organization}/*"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "githubactions_infra_role_policy" {
+  name = "${aws_iam_role.githubactions_infra_role.name}-policy"
+  role = aws_iam_role.githubactions_infra_role.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetServiceBearerToken",
+        "ec2:*",
+        "elasticloadbalancing:*",
+        "s3:*",
+        "ecr:*",
+        "eks:*",
+        "cloudfront:*",
+        "sqs:*",
+        "sns:*",
+        "rds:*",
+        "dynamodb:*",
+        "elasticache:*",
+        "route53:*",
+        "acm:*",
+        "cloudwatch:*",
+        "logs:*",
+        "iam:CreatePolicy",
+        "iam:DetachRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:DeletePolicy",
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:AttachRolePolicy",
+        "iam:UpdateRole",
+        "iam:PutRolePolicy",
+        "iam:TagRole",
+        "iam:TagPolicy",
+        "iam:CreateUser"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PasRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassToService": "eks.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/aws/platform/modules/oidc/main.tf
+++ b/aws/platform/modules/oidc/main.tf
@@ -143,7 +143,7 @@ resource "aws_iam_role_policy" "githubactions_infra_role_policy" {
     },
     {
       "Effect": "Allow",
-      "Action": "iam:PasRole",
+      "Action": "iam:PassRole",
       "Resource": "*",
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
nautible-infraのGithubActionsからAWSのアクセスをOIDCに変更。
また変更に伴い、AWS側のgh-infra-userは削除、Github側のシークレット設定も変更。
ロールに付与するポリシーはgh-infra-userに設定されていたものと同一にしています。

現在nautible-infraはGithubActionsを有効化していないので実際にCIは回していないですが（Cloudfrontの設定とかもあるので単純には回せない）、一旦アプリ側と同一対応まで終わったのでここまでで反映しておきます。

また、issueとは別ですが、EKSのtagの綴りだけついでに修正。