### PR TITLE
nautible/issues#82

### DIFF
--- a/azure/platform/env/dev/variables.tf
+++ b/azure/platform/env/dev/variables.tf
@@ -27,6 +27,7 @@ variable "aks" {
     max_pods                                  = number
     log_analytics_workspace_retention_in_days = number
     cluster_inbound_http_port_range           = string
+    api_server_authorized_ip_ranges           = list(string)
     subnet = object({
       cidrs = list(string)
       names = list(string)
@@ -49,6 +50,8 @@ variable "aks" {
     log_analytics_workspace_retention_in_days = 30
     # inbound http port range. e.g "80,8080-8082"
     cluster_inbound_http_port_range = "80"
+    # api server authorized ip ranges
+    api_server_authorized_ip_ranges = []
     subnet = {
       # cidr
       cidrs = ["192.168.0.0/16", "192.169.0.0/16"]

--- a/azure/platform/main.tf
+++ b/azure/platform/main.tf
@@ -44,6 +44,7 @@ module "aks" {
   node_availability_zones                   = var.aks.node.availability_zones
   max_pods                                  = var.aks.max_pods
   log_analytics_workspace_retention_in_days = var.aks.log_analytics_workspace_retention_in_days
+  api_server_authorized_ip_ranges           = var.aks.api_server_authorized_ip_ranges
   acr_id                                    = module.acr.acr_id
 }
 

--- a/azure/platform/modules/aks/main.tf
+++ b/azure/platform/modules/aks/main.tf
@@ -117,6 +117,8 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
 
   role_based_access_control_enabled = true
 
+  api_server_authorized_ip_ranges = var.api_server_authorized_ip_ranges
+
   tags = var.tags
 
   lifecycle {

--- a/azure/platform/modules/aks/variables.tf
+++ b/azure/platform/modules/aks/variables.tf
@@ -31,4 +31,5 @@ variable "node_count" {}
 variable "node_availability_zones" {}
 variable "max_pods" {}
 variable "log_analytics_workspace_retention_in_days" {}
+variable "api_server_authorized_ip_ranges" {}
 variable "acr_id" {}


### PR DESCRIPTION
AKSのAPIをOGIS-IP制限へ。本件もapi_server_authorized_ip_rangesはnullでgithub管理し。
実行時にはOGISのIPを設定して運用する予定です。
