### PR TITLE
nautible/issues#97 権限の設定漏れ

### DIFF
--- a/aws/platform/modules/oidc/main.tf
+++ b/aws/platform/modules/oidc/main.tf
@@ -185,6 +185,7 @@ resource "aws_iam_role_policy" "githubactions_static_web_deploy_role_policy" {
         Action = [
           "s3:PutObject",
           "s3:GetObject",
+          "s3:DeleteObject",
           "s3:ListBucket"
         ],
         Resource = [


### PR DESCRIPTION
frontのgithub action deployの権限に設定漏れがあったので対応。