### PR TITLE
Proposal: Allow setting of AMI ID for node group.

### DIFF
--- a/aws/platform/env/dev/variables.tf
+++ b/aws/platform/env/dev/variables.tf
@@ -62,6 +62,7 @@ variable "eks" {
       min_size      = number
       instance_type = string
       ami_type      = string
+      ami_id        = string
       disk_size     = number
     })
     albc_security_group_cloudfront_prefix_list_id = string
@@ -114,6 +115,11 @@ variable "eks" {
         instance_type = "t3.medium"
         # ami type
         ami_type = "AL2_x86_64"
+        # ami id
+        # Allows setting of specific AMI ID to be used for EKS node group creation.
+        # e.g. Ubuntu EKS Worker Node image
+        # **make sure pre_bootstrap_user_data in EKS module is valid for the image**
+        # ami_id = ""
         # disk size
         disk_size = 16
       }

--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -34,6 +34,7 @@ module "eks" {
   ng_min_size                                   = each.value.node_group.min_size
   ng_instance_type                              = each.value.node_group.instance_type
   ng_ami_type                                   = each.value.node_group.ami_type
+  ng_ami_id                                     = each.value.node_group.ami_id
   ng_disk_size                                  = each.value.node_group.disk_size
   albc_security_group_cloudfront_prefix_list_id = each.value.albc_security_group_cloudfront_prefix_list_id
 }

--- a/aws/platform/modules/eks/main.tf
+++ b/aws/platform/modules/eks/main.tf
@@ -49,6 +49,7 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     ami_type                               = var.ng_ami_type
+    ami_id                                 = var.ng_ami_id
     disk_size                              = var.ng_disk_size
     update_launch_template_default_version = true
     iam_role_name                          = "${var.cluster_name}-AmazonEKSNodeRole"

--- a/aws/platform/modules/eks/variables.tf
+++ b/aws/platform/modules/eks/variables.tf
@@ -12,6 +12,7 @@ variable "ng_max_size" {}
 variable "ng_min_size" {}
 variable "ng_instance_type" {}
 variable "ng_ami_type" {}
+variable "ng_ami_id" {}
 variable "ng_disk_size" {}
 variable "cluster_endpoint_private_access" {}
 variable "cluster_endpoint_public_access" {}


### PR DESCRIPTION
This allows usage of custom AMIs like Ubuntu on Amazon Elastic Kubernetes Service images for the node group.
Also added note to highlight importance of checking whether the currently set pre_bootstrap_user_data in the EKS module is valid for the AMI ID to be set. Feel free to close without merging if this is deemed not needed or an internal commit has already addressed this proposal.