### PR TITLE
Feature/issues167

### DIFF
--- a/aws/app-ms/env/dev/main.tf
+++ b/aws/app-ms/env/dev/main.tf
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.66.0"
+      version = "~> 5.89.0"
     }
   }
 }

--- a/aws/app-ms/env/dev/variables.tf
+++ b/aws/app-ms/env/dev/variables.tf
@@ -16,7 +16,7 @@ variable "region" {
 # platform tfstate
 variable "platform_tfstate" {
   description = "platform tfstate設定"
-  default = "nautible-dev-platform.tfstate"
+  default     = "nautible-dev-platform.tfstate"
 }
 
 locals {
@@ -39,6 +39,7 @@ variable "order" {
   description = "ORDER設定"
   type = object({
     elasticache = object({
+      engine               = string
       engine_version       = string
       node_type            = string
       parameter_group_name = string
@@ -48,12 +49,14 @@ variable "order" {
   default = {
     # elasticache
     elasticache = {
+      # engine
+      engine = "valkey"
       # engine version
-      engine_version = "7.1"
+      engine_version = "8.0"
       # node type
       node_type = "cache.t4g.micro"
       # parameter group name
-      parameter_group_name = "default.redis7"
+      parameter_group_name = "default.valkey8"
       # port
       port = 6379
     }

--- a/aws/app-ms/env/dev/variables.tf
+++ b/aws/app-ms/env/dev/variables.tf
@@ -42,6 +42,7 @@ variable "order" {
       engine               = string
       engine_version       = string
       node_type            = string
+      cache_clusters       = number
       parameter_group_name = string
       port                 = number
     })
@@ -55,6 +56,8 @@ variable "order" {
       engine_version = "8.0"
       # node type
       node_type = "cache.t4g.micro"
+      # number cache_clusters
+      cache_clusters = 1
       # parameter group name
       parameter_group_name = "default.valkey8"
       # port

--- a/aws/app-ms/main.tf
+++ b/aws/app-ms/main.tf
@@ -50,6 +50,7 @@ module "order" {
   private_zone_name                      = var.vpc.private_zone_name
   eks_node_security_group_ids            = values(var.eks).*.node.security_group_id
   order_elasticache_node_type            = var.order.elasticache.node_type
+  order_elasticache_cache_clusters       = var.order.elasticache.cache_clusters
   order_elasticache_parameter_group_name = var.order.elasticache.parameter_group_name
   order_elasticache_engine               = var.order.elasticache.engine
   order_elasticache_engine_version       = var.order.elasticache.engine_version

--- a/aws/app-ms/main.tf
+++ b/aws/app-ms/main.tf
@@ -51,6 +51,7 @@ module "order" {
   eks_node_security_group_ids            = values(var.eks).*.node.security_group_id
   order_elasticache_node_type            = var.order.elasticache.node_type
   order_elasticache_parameter_group_name = var.order.elasticache.parameter_group_name
+  order_elasticache_engine               = var.order.elasticache.engine
   order_elasticache_engine_version       = var.order.elasticache.engine_version
   order_elasticache_port                 = var.order.elasticache.port
 }

--- a/aws/app-ms/modules/order/main.tf
+++ b/aws/app-ms/modules/order/main.tf
@@ -42,6 +42,7 @@ resource "aws_elasticache_replication_group" "order_elasticache_replication_grou
   node_type                  = var.order_elasticache_node_type
   engine                     = var.order_elasticache_engine
   engine_version             = var.order_elasticache_engine_version
+  num_cache_clusters         = var.order_elasticache_cache_clusters
   parameter_group_name       = var.order_elasticache_parameter_group_name
   port                       = var.order_elasticache_port
   subnet_group_name          = aws_elasticache_subnet_group.order_elasticache_subnet_group.name

--- a/aws/app-ms/modules/order/main.tf
+++ b/aws/app-ms/modules/order/main.tf
@@ -40,6 +40,7 @@ resource "aws_elasticache_replication_group" "order_elasticache_replication_grou
   replication_group_id       = "order-statestore"
   description                = "order statestore"
   node_type                  = var.order_elasticache_node_type
+  engine                     = var.order_elasticache_engine
   engine_version             = var.order_elasticache_engine_version
   parameter_group_name       = var.order_elasticache_parameter_group_name
   port                       = var.order_elasticache_port

--- a/aws/app-ms/modules/order/main.tf
+++ b/aws/app-ms/modules/order/main.tf
@@ -50,11 +50,6 @@ resource "aws_elasticache_replication_group" "order_elasticache_replication_grou
   auth_token                 = data.aws_ssm_parameter.order_elasticache_password.value
 }
 
-resource "aws_elasticache_cluster" "order_elasticache" {
-  cluster_id           = "order-statestore"
-  replication_group_id = aws_elasticache_replication_group.order_elasticache_replication_group.id
-}
-
 resource "aws_route53_record" "order_statestore_r53record" {
   zone_id = var.private_zone_id
   name    = "order-statestore.${var.private_zone_name}"

--- a/aws/app-ms/modules/order/variables.tf
+++ b/aws/app-ms/modules/order/variables.tf
@@ -5,6 +5,7 @@ variable "private_subnets" {}
 variable "eks_node_security_group_ids" {}
 variable "order_elasticache_node_type" {}
 variable "order_elasticache_parameter_group_name" {}
+variable "order_elasticache_engine" {}
 variable "order_elasticache_engine_version" {}
 variable "order_elasticache_port" {}
 variable "private_zone_id" {}

--- a/aws/app-ms/modules/order/variables.tf
+++ b/aws/app-ms/modules/order/variables.tf
@@ -4,6 +4,7 @@ variable "vpc_id" {}
 variable "private_subnets" {}
 variable "eks_node_security_group_ids" {}
 variable "order_elasticache_node_type" {}
+variable "order_elasticache_cache_clusters" {}
 variable "order_elasticache_parameter_group_name" {}
 variable "order_elasticache_engine" {}
 variable "order_elasticache_engine_version" {}


### PR DESCRIPTION
パラメータengineを追加してValkeyを指定できるように変更。
aws_elasticache_clusterはValkeyではサポートされていないため削除
※Valkey、Redisともクラスタを組む際はaws_elasticache_replication_groupにnum_cache_clustersに2以上を指定することで対応可能